### PR TITLE
fix: set maxUnavailable for ovs rolling update strategy

### DIFF
--- a/openvswitch/values.yaml
+++ b/openvswitch/values.yaml
@@ -112,8 +112,7 @@ pod:
         ovs:
           enabled: true
           min_ready_seconds: 0
-          max_unavailable: 0
-          max_surge: 1
+          max_unavailable: 1
   resources:
     enabled: false
     ovs:


### PR DESCRIPTION
`maxSurge` and `maxUnavailable` are mutually exclusive in the DaemonSet update logic.
When `maxSurge` is non-zero, `maxUnavailable` is ignored; when `maxSurge` is zero, only `maxUnavailable` is used. We need to make sure availability so keep `maxUnavailable`.